### PR TITLE
allow usage of currently checked out branch

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+<a name="1.4.2"></a>
+## [1.4.2](https://github.com/blankogmbh/kirby-git-commit-and-push-content/compare/v1.4.1...v1.4.2) (2017-02-09)
+
+
+
+
 <a name="1.4.1"></a>
 ## [1.4.1](https://github.com/blankogmbh/kirby-git-commit-and-push-content/compare/v1.4.0...v1.4.1) (2017-02-08)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,22 @@
+<a name="2.0.0"></a>
+# [2.0.0](https://github.com/blankogmbh/kirby-git-commit-and-push-content/compare/1.4.2...v2.0.0) (2017-02-20)
+
+
+### Bug Fixes
+
+* use slashes for url, not DS ([d4e24b7](https://github.com/blankogmbh/kirby-git-commit-and-push-content/commit/d4e24b7))
+
+### Features
+
+* allow usage of currently checked out branch ([033d10f](https://github.com/blankogmbh/kirby-git-commit-and-push-content/commit/033d10f))
+
+
+### BREAKING CHANGES
+
+* the default branch is not the master anymore
+
+
+
 <a name="1.4.2"></a>
 ## [1.4.2](https://github.com/blankogmbh/kirby-git-commit-and-push-content/compare/v1.4.1...v1.4.2) (2017-02-09)
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "blankogmbh/kirby-git-commit-and-push-content",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "require": {
     "getkirby/kirby": "^2.1",
     "pascalmh/git.php": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "blankogmbh/kirby-git-commit-and-push-content",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "require": {
     "getkirby/kirby": "^2.1",
     "pascalmh/git.php": "^1.0"

--- a/helpers.php
+++ b/helpers.php
@@ -14,7 +14,7 @@ class KirbyGitHelper
     public function __construct($repoPath = false)
     {
         $this->repoPath = $repoPath ? $repoPath : kirby()->roots()->content();
-        $this->branch = c::get('gcapc-branch', 'master');
+        $this->branch = c::get('gcapc-branch', '');
     }
 
     private function initRepo()
@@ -81,7 +81,9 @@ class KirbyGitHelper
 
     public function kirbyChange($commitMessage)
     {
-        $this->getRepo()->checkout($this->branch);
+        if ($this->branch) {
+            $this->getRepo()->checkout($this->branch);
+        }
 
         if ($this->pullOnChange) {
             $this->pull();

--- a/helpers.php
+++ b/helpers.php
@@ -80,7 +80,7 @@ class KirbyGitHelper
     }
 
     public function kirbyChange($commitMessage)
-    {   
+    {
         try {
             if ($this->branch) {
               $this->getRepo()->checkout($this->branch);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "git-commit-and-push-content",
   "readable": "Git Commit and Push Content",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/blankogmbh/kirby-git-commit-and-push-content.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "git-commit-and-push-content",
   "readable": "Git Commit and Push Content",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/blankogmbh/kirby-git-commit-and-push-content.git"

--- a/readme.md
+++ b/readme.md
@@ -82,9 +82,9 @@ If you do not want to Pull and/or Push on every change you can also call `yourdo
 
 #### gcapc-branch
 Type: `String`
-Default value: `'master'`
+Default value: `''`
 
-branch name to be checked out
+branch name to be checked out (defauts to currently checked out branch)
 
 #### gcapc-pull
 Type: `Boolean`

--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,19 @@ Default value: `false`
 
 [See Git.php](http://kbjr.github.io/Git.php/) `void Git::windows_mode ( void )`
 
+## Git LFS
+Your repository might increase over time, by adding Images, Audio, Video, Binaries, etc. 
+cloning and updating your content repostory can take a lot of time. If you are able to use
+[Git LFS](https://git-lfs.github.com/) you probably should. Here is what the .gitattributes-File could look like:
+
+```
+*.zip filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
+```
+
 ## Author
 
 Pascal 'Pascalmh' Küsgen <http://pascalmh.de>

--- a/widgets/git-commit-and-push-content/git-commit-and-push-content.html.php
+++ b/widgets/git-commit-and-push-content/git-commit-and-push-content.html.php
@@ -2,7 +2,9 @@
 
 <div class="gcapc-info">
     <ul class="gcapc-info-list">
-        <li>Branch: <?= c::get('gcapc-branch', 'master') ?></li>
+        <?php if (c::get('gcapc-branch') && c::get('gcapc-branch') != ''): ?>
+            <li>Branch: <?= c::get('gcapc-branch') ?></li>
+        <?php endif ?>
         <li>Committing: <i class="icon fa fa-<?= c::get('gcapc-commit', false) ? 'check' : 'times' ?>"></i></li>
         <li>Pulling: <i class="icon fa fa-<?= c::get('gcapc-pull', false) ? 'check' : 'times' ?>"></i></li>
         <li>Pushing: <i class="icon fa fa-<?= c::get('gcapc-push', false) ? 'check' : 'times' ?>"></i></li>

--- a/widgets/git-commit-and-push-content/git-commit-and-push-content.php
+++ b/widgets/git-commit-and-push-content/git-commit-and-push-content.php
@@ -1,19 +1,19 @@
 <?php
-return array(
+return [
     'title' => 'GCAPC',
-    'options' => array(
-        array(
+    'options' => [
+        [
             'text' => 'Pull',
             'icon' => 'arrow-down',
             'link' => kirby()->urls()->index() . '/gcapc/pull',
-        ),
-        array(
+        ],
+        [
             'text' => 'Push',
             'icon' => 'arrow-up',
             'link' => kirby()->urls()->index() . '/gcapc/push',
-        )
-    ),
+        ]
+    ],
     'html' => function () {
         return tpl::load(__DIR__ . DS . 'git-commit-and-push-content.html.php');
     }
-);
+];

--- a/widgets/git-commit-and-push-content/git-commit-and-push-content.php
+++ b/widgets/git-commit-and-push-content/git-commit-and-push-content.php
@@ -5,12 +5,12 @@ return array(
         array(
             'text' => 'Pull',
             'icon' => 'arrow-down',
-            'link' => kirby()->urls()->index() . DS . 'gcapc' . DS . 'pull',
+            'link' => kirby()->urls()->index() . '/gcapc/pull',
         ),
         array(
             'text' => 'Push',
             'icon' => 'arrow-up',
-            'link' => kirby()->urls()->index() . DS . 'gcapc' . DS . 'push',
+            'link' => kirby()->urls()->index() . '/gcapc/push',
         )
     ),
     'html' => function () {


### PR DESCRIPTION
This will be a **breaking change** release (so 2.0.0) as we change the default behaviour of the plugin, the default branch won't be the 'master' anymore but the currently checked out branch.