### PR TITLE
Improved error handling.

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -81,16 +81,20 @@ class KirbyGitHelper
 
     public function kirbyChange($commitMessage)
     {
-        $this->getRepo()->checkout($this->branch);
+        try {
+            $this->getRepo()->checkout($this->branch);
 
-        if ($this->pullOnChange) {
-            $this->pull();
-        }
-        if ($this->commitOnChange) {
-            $this->commit($commitMessage . "\n\nby " . site()->user());
-        }
-        if ($this->pushOnChange) {
-            $this->push();
+            if ($this->pullOnChange) {
+                $this->pull();
+            }
+            if ($this->commitOnChange) {
+                $this->commit($commitMessage . "\n\nby " . site()->user());
+            }
+            if ($this->pushOnChange) {
+                $this->push();
+            }
+        } catch(Exception $exception) {
+            trigger_error('Unable to update git: ' . $exception->getMessage());
         }
     }
 }


### PR DESCRIPTION
Right now the plugin does not trigger any errors if anything goes wrong inside the `kirbyChange` function. 

This pull request will catch exceptions from the `Git.php` call and trigger them as error messages into a log file.